### PR TITLE
Update html parsing with escape characters and tooltip popup window

### DIFF
--- a/WebGUI/html/FEMacroTest.html
+++ b/WebGUI/html/FEMacroTest.html
@@ -335,6 +335,7 @@
 						for(var i=0;i<feMacros.length;++i)
 						{
 							macroVar = feMacros[i].getAttribute("value");
+							Debug.log("Help [macroVar]", feMacros[i].getAttribute("value"));
 							Debug.log(macroVar);
 							macroVar = macroVar.split(";");
 
@@ -365,6 +366,7 @@
 									Debug.log("Need to create FE to FE Macro map entry.");							
 									feToMacrosMap_[feUID] = {};
 								}
+								Debug.log("Help [macroVar[c+2]", macroVar[c+2]);
 								feToMacrosMap_[feUID][macroName] = 
 								{
 										"requiredPermissions": 	macroVar[c+1],
@@ -514,7 +516,7 @@
 				
 					}); //end getFEMacroList handler
 		} //end init()
-	
+
 		//=====================================================================================
 		//runMacro ~~
 		var verticalOutputDivSize_ = [600,1000];
@@ -1652,6 +1654,8 @@
 			console.log("feMacroNameSelected",feMacroNameSelected);
 
 			var macroNameObject = macroModules_[r][c].feMacroNameObject;
+
+			Debug.log("Help [macroNameObject]", macroNameObject);
 			
 			if(!feMacroNameSelected || feMacroNameSelected == "")
 			{
@@ -1677,8 +1681,6 @@
 			var inputsArr 	= macroObj.inputs;
 			var outputsArr 	= macroObj.outputs;
 			var tooltip 	= macroObj.tooltip;
-			if(tooltip != "")
-				DesktopContent.tooltip(macroName,tooltip);
 
 			//var supervisor 	= macroObj.supervisor;
 			//var lid 		= macroObj.lid;
@@ -1691,7 +1693,15 @@
 			str += "<b>&quot;" + macroName + "()&quot;</b> RequiredPermissions=" + requiredPermissions;
 			if (tooltip != "")
 			{
-				str += "<span class='macroInfo' title='" + tooltip + "'></span>";
+				Debug.log("Help [macro tooltip]", tooltip)
+				str += DesktopContent.htmlOpen("span",{
+						"class" : "macroInfo",
+						"style" : "cursor:pointer",
+						"onclick" : ("DesktopContent.tooltip(\"" + 
+							macroName + "\", \"" + 
+							DesktopContent.tooltipConditionString(tooltip) + "\");"),
+						"title" : "Click to open the tooltip for FE Macro &apos;" + macroName + "&apos;"
+					},"" /*innerHTML*/,true /*doCloseTag*/);					
 			}
 					
 			str += "<br>" +

--- a/WebGUI/js/DesktopContent.js
+++ b/WebGUI/js/DesktopContent.js
@@ -1535,7 +1535,8 @@ DesktopContent.tooltipConditionString = function(str) {
 			"<div style='margin-left:60px;'>").replace(/<\/INDENT>/g,
 					"</div>").replace(/<TAB>/g,
 							"<div style='margin-left:60px;'>").replace(/<\/TAB>/g,
-									"</div>");
+									"</div>").replace(/\n/g,
+										"<br>");
 } //end tooltipConditionString()
 
 //=====================================================================================
@@ -2733,6 +2734,16 @@ DesktopContent.getExceptionLineNumber = function(e)
 
 //=====================================================================================
 //	provide html tag name and attribute/value map object
+//		To escape quotes in usage, use \" for example and use encodeURIComponent(str) to avoid special characters:
+//
+// 		str += DesktopContent.htmlOpen("span",{
+// 			"class" : "macroInfo",
+// 			"style" : "cursor:pointer",
+// 			"onclick" : ("DesktopContent.tooltip(\"" + 
+// 				encodeURIComponent(macroName) + "\", \"" + 
+// 				encodeURIComponent(tooltip) + "\");"),
+// 			"title" : "Click to open the tooltip for FE Macro &apos;" + encodeURIComponent(macroName) + "&apos;"
+// 		},"" /*innerHTML*/,true /*doCloseTag*/);					
 DesktopContent.htmlOpen = function(tag, attObj, innerHTML, doCloseTag)
 {
 	var str = "";
@@ -2748,8 +2759,13 @@ DesktopContent.htmlOpen = function(tag, attObj, innerHTML, doCloseTag)
 		else if(attKeys[i] == "checked") str += (attObj[attKeys[i]]|0)?" checked ":""; //no value
 		else if(attKeys[i] == "") continue; //skip empty key
 		else
+		{
+			var tmpStr = attObj[attKeys[i]];
+			if(typeof(tmpStr) == "string")
+				tmpStr = tmpStr.replaceAll("'","\\'");
 			str += " " + attKeys[i] + "='" +
-			attObj[attKeys[i]] + "' ";
+				tmpStr + "' ";
+		}
 	}
 	str += ">";
 	if(innerHTML) 


### PR DESCRIPTION
This PR:
- Disables the tooltip window when selecting a FE Macro. Users must hover or click on the tooltip icon for more info. 
- Updates the HTML parsing for escape characters in htmlOpen