### PR TITLE
Scorrodi/FSM

### DIFF
--- a/WebGUI/html/StateMachine.html
+++ b/WebGUI/html/StateMachine.html
@@ -301,7 +301,7 @@
 			var _MIN_WIN_SZ_FOR_ALT_BIG_STATES = 750;  //canvas must be at least this size for big state drawing
 			var _MIN_WIN_SZ = 350;  //canvas is forced to at least this size
 			var _SM_MODE_STATE_SZ = 40;
-			var _LG_MODE_STATE_SZ = 80;
+			var _LG_MODE_STATE_SZ = 100;
 			var _CANVAS_STATE_MARGIN = 10;
 			var _ARROW_MARGIN = 6;
 			var _CURR_STATE_COLOR = "#8ED6FF";
@@ -326,8 +326,8 @@
 			var _HUD_H = 54;
 
 
-			var _PARAMETER_SETUP_MIN_HEIGHT = 25;
-			var _PARAMETER_SETUP_MAX_HEIGHT = 80;
+			var _PARAMETER_SETUP_MIN_HEIGHT = 45;
+			var _PARAMETER_SETUP_MAX_HEIGHT = 100;
 			var _PARAMETER_SETUP_WIDTH = 150;
 
 			var _EXTRAS_WIDTH = 220;
@@ -463,6 +463,7 @@
 					Debug.log("_fsmName=" + _fsmName);
 				else
 					_fsmName = "";
+
 
 				try	{ _fsmWindowName = DesktopContent.getDesktopWindowTitle(); }
 				catch(e) {;} //ignore any errors (like cross-origin)
@@ -608,7 +609,7 @@
 				if (!req) //first time
 				{
 					_transParamsHtmlStr = //clear
-					"<a href='Javascript:toggleConfigurationAliasSelect();' title='Toggle hide/show of Configuration Alias selection pane'>Config Alias</a><br><br>";
+					'<div style="font-size:smaller;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;padding-bottom: 5px;">FSM: ' + _fsmName + "</div><a href='Javascript:toggleConfigurationAliasSelect();' title='Toggle hide/show of Configuration Alias selection pane'>Config Alias</a><br><br>";
 
 					_parameterInitCount = 0;
 

--- a/WebGUI/html/StateMachine.html
+++ b/WebGUI/html/StateMachine.html
@@ -301,7 +301,7 @@
 			var _MIN_WIN_SZ_FOR_ALT_BIG_STATES = 750;  //canvas must be at least this size for big state drawing
 			var _MIN_WIN_SZ = 350;  //canvas is forced to at least this size
 			var _SM_MODE_STATE_SZ = 40;
-			var _LG_MODE_STATE_SZ = 100;
+			var _LG_MODE_STATE_SZ = 80;
 			var _CANVAS_STATE_MARGIN = 10;
 			var _ARROW_MARGIN = 6;
 			var _CURR_STATE_COLOR = "#8ED6FF";


### PR DESCRIPTION
If I understand correctly, we set the FSM of a State Machine window in the URL. That's quite hidden and threw me off. I think it would be beneficial to display the FSM name (fsm_name) of a window. 
<img width="564" height="314" alt="Screenshot 2025-10-11 at 12 18 18 AM" src="https://github.com/user-attachments/assets/e8bb3754-8a8f-45b8-925f-9a24e85f5567" />
 