### PR TITLE
Better handling for large Macromaker systems (throttle UDP sends); be…

### DIFF
--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -133,7 +133,7 @@ MacroMakerSupervisor::MacroMakerSupervisor(xdaq::ApplicationStub* stub)
 			__ENV__("OTS_MACROMAKER_UDP_IP");
 			enableRemoteControl = true;
 		}
-		catch(const std::exception& e)
+		catch(const std::runtime_error& e)
 		{
 			__SUP_COUT__ << "Ignoring MacroMaker server env var error: " << e.what()
 			             << __E__;

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -133,9 +133,9 @@ MacroMakerSupervisor::MacroMakerSupervisor(xdaq::ApplicationStub* stub)
 			__ENV__("OTS_MACROMAKER_UDP_IP");
 			enableRemoteControl = true;
 		}
-		catch(...)
+		catch(const std::runtime_error& e)
 		{
-			;
+			__SUP_COUT__ << "Ignoring MacroMaker server env var error: " << e.what() << __E__;
 		}  // ignore errors
 
 		if(enableRemoteControl)
@@ -531,7 +531,7 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					                         false /*dispStdOut*/,
 					                         false /*allowWhiteSpace*/);
 					__COUT__ << "out: " << out.str();
-					sock.acknowledge(out.str(), true /* verbose */);
+					sock.acknowledge(out.str(), true /* verbose */, 1500 /* max chunk size*/, 1000 /* inter-chunk delay us */);
 				}
 				else if(buffer.find("RunFrontendMacro") == 0)
 				{
@@ -560,23 +560,146 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					std::string username            = "NO-USER";
 					std::string userGroupPermission = "allUsers: 255";
 
-					theSupervisor->runFEMacro(xmldoc,
-					                          feClassSelected,
-					                          feUIDSelected,
-					                          macroType,
-					                          macroName,
-					                          inputArgs,
-					                          outputArgs,
-					                          saveOutputs,
-					                          username,
-					                          userGroupPermission);
+					// Build the same per-UID group execution model used by CGI runFEMacro
+					std::set<std::string> feUIDs;
+					{
+						std::string expandUID = feUIDSelected.empty() ? "*" : feUIDSelected;
+						if(expandUID != "*")
+							StringMacros::getSetFromString(expandUID, feUIDs);
+						else
+						{
+							for(auto& feTypePair : theSupervisor->FEPluginTypetoFEsMap_)
+							{
+								if(feClassSelected.empty() || feClassSelected == "*" ||
+								   feClassSelected == feTypePair.first)
+									for(auto& uid : feTypePair.second)
+										feUIDs.emplace(uid);
+							}
+						}
+						if(feUIDs.empty())
+							feUIDs.emplace(feUIDSelected);  // fallback to existing error behavior
+					}
+
+					auto group                     = std::make_shared<runFEMacroGroupStruct>();
+					group->historyFeClassSelected_ =
+					    feClassSelected.empty() ? "*" : feClassSelected;
+					group->historyFeUIDSelected_ =
+					    feUIDSelected.empty() ? "*" : feUIDSelected;
+					group->historyMacroType_   = macroType;
+					group->historyMacroName_   = macroName;
+					group->historyInputArgs_   = inputArgs;
+					group->historyOutputArgs_  = outputArgs;
+					group->historySaveOutputs_ = saveOutputs;
+					group->historyUsername_    = username;
+
+					for(const std::string& uid : feUIDs)
+						group->tasks_.push_back(std::make_shared<runFEMacroStruct>(
+						    xmldoc,
+						    feClassSelected,
+						    uid,
+						    macroType,
+						    macroName,
+						    inputArgs,
+						    outputArgs,
+						    saveOutputs,
+						    username,
+						    userGroupPermission));
+
+					{
+						std::lock_guard<std::mutex> lock(
+						    theSupervisor->feMacroRunThreadStructMutex_);
+						group->groupID_ = ++theSupervisor->feMacroRunGroupIDCounter_;
+						if(theSupervisor->feMacroRunGroupIDCounter_ == 0)
+							group->groupID_ = ++theSupervisor->feMacroRunGroupIDCounter_;
+
+						for(auto& task : group->tasks_)
+						{
+							task->bar_ = std::make_unique<ProgressBar>();
+							task->bar_->reset(macroName, task->parameters_.feUIDSelected_);
+						}
+						theSupervisor->feMacroRunThreadStruct_.emplace_back(group);
+					}
+
+					std::thread([group, theSupervisor]() {
+						MacroMakerSupervisor::runFEMacroGroupSchedulerThread(
+						    group, theSupervisor);
+					}).detach();
+
+					auto lastProgressSend = std::chrono::steady_clock::now();
+					while(!group->allDone())
+					{
+						usleep(100 * 1000);  // poll at 100 ms
+
+						auto now = std::chrono::steady_clock::now();
+						if(std::chrono::duration_cast<std::chrono::seconds>(now - lastProgressSend)
+						       .count() >= 2)
+						{
+							lastProgressSend = now;
+
+							int totalProgress = 0;
+							int taskCount      = 0;
+							{
+								std::lock_guard<std::mutex> lock(
+								    theSupervisor->feMacroRunThreadStructMutex_);
+								for(auto& task : group->tasks_)
+								{
+									++taskCount;
+									if(task->feMacroRunDone_)
+										totalProgress += 100;
+									else if(task->bar_)
+										totalProgress += task->bar_->read();
+								}
+							}
+
+							int percent = (taskCount > 0) ? (totalProgress / taskCount) : 0;
+							if(percent >= 100)
+								percent = 99;
+
+							__COUTV__(percent);
+							sock.acknowledge(
+							    std::string("<progress>") + std::to_string(percent) +
+							        "</progress>",
+							    true /* verbose */);
+						}
+					}
+
+					for(auto& task : group->tasks_)
+					{
+						if(task->parameters_.feMacroRunError_ != "")
+						{
+							__SS__ << task->parameters_.feMacroRunError_;
+							{
+								xmldoc.addTextElementToData("Error", ss.str());
+								std::stringstream out;
+								xmldoc.outputXmlDocument((std::ostringstream*)&out,
+														false /*dispStdOut*/,
+														true /*allowWhiteSpace*/);
+								__COUT__ << "out: " << out.str();
+								sock.acknowledge(out.str(), true /* verbose */);
+							}
+							__SS_THROW__;
+						}
+						xmldoc.copyDataChildren(task->parameters_.xmldoc_);
+					}
+
+					{
+						std::lock_guard<std::mutex> lock(
+						    theSupervisor->feMacroRunThreadStructMutex_);
+						for(size_t i = 0; i < theSupervisor->feMacroRunThreadStruct_.size(); ++i)
+							if(theSupervisor->feMacroRunThreadStruct_[i].get() == group.get())
+							{
+								theSupervisor->feMacroRunThreadStruct_.erase(
+								    theSupervisor->feMacroRunThreadStruct_.begin() + i);
+								break;
+							}
+					}
 
 					std::stringstream out;
 					xmldoc.outputXmlDocument((std::ostringstream*)&out,
 					                         false /*dispStdOut*/,
 					                         true /*allowWhiteSpace*/);
 					__COUT__ << "out: " << out.str();
-					sock.acknowledge(out.str(), true /* verbose */);
+					sock.acknowledge(out.str(), true /* verbose */, 1500 /* max chunk size*/, 1000 /* inter-chunk delay us */);
 				}
 				else
 				{

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -133,10 +133,15 @@ MacroMakerSupervisor::MacroMakerSupervisor(xdaq::ApplicationStub* stub)
 			__ENV__("OTS_MACROMAKER_UDP_IP");
 			enableRemoteControl = true;
 		}
-		catch(const std::runtime_error& e)
+		catch(const std::exception& e)
 		{
 			__SUP_COUT__ << "Ignoring MacroMaker server env var error: " << e.what()
 			             << __E__;
+		}
+		catch(...)
+		{
+			__SUP_COUT__ << "Ignoring unknown error reading OTS_MACROMAKER_UDP_PORT/"
+			                "OTS_MACROMAKER_UDP_IP env vars." << __E__;
 		}  // ignore errors
 
 		if(enableRemoteControl)

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -676,15 +676,6 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 						if(task->parameters_.feMacroRunError_ != "")
 						{
 							__SS__ << task->parameters_.feMacroRunError_;
-							{
-								xmldoc.addTextElementToData("Error", ss.str());
-								std::stringstream out;
-								xmldoc.outputXmlDocument((std::ostringstream*)&out,
-								                         false /*dispStdOut*/,
-								                         true /*allowWhiteSpace*/);
-								__COUT__ << "out: " << out.str();
-								sock.acknowledge(out.str(), true /* verbose */);
-							}
 							__SS_THROW__;
 						}
 						xmldoc.copyDataChildren(task->parameters_.xmldoc_);

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -135,7 +135,8 @@ MacroMakerSupervisor::MacroMakerSupervisor(xdaq::ApplicationStub* stub)
 		}
 		catch(const std::runtime_error& e)
 		{
-			__SUP_COUT__ << "Ignoring MacroMaker server env var error: " << e.what() << __E__;
+			__SUP_COUT__ << "Ignoring MacroMaker server env var error: " << e.what()
+			             << __E__;
 		}  // ignore errors
 
 		if(enableRemoteControl)
@@ -531,7 +532,10 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					                         false /*dispStdOut*/,
 					                         false /*allowWhiteSpace*/);
 					__COUT__ << "out: " << out.str();
-					sock.acknowledge(out.str(), true /* verbose */, 1500 /* max chunk size*/, 1000 /* inter-chunk delay us */);
+					sock.acknowledge(out.str(),
+					                 true /* verbose */,
+					                 1500 /* max chunk size*/,
+					                 1000 /* inter-chunk delay us */);
 				}
 				else if(buffer.find("RunFrontendMacro") == 0)
 				{
@@ -563,7 +567,8 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					// Build the same per-UID group execution model used by CGI runFEMacro
 					std::set<std::string> feUIDs;
 					{
-						std::string expandUID = feUIDSelected.empty() ? "*" : feUIDSelected;
+						std::string expandUID =
+						    feUIDSelected.empty() ? "*" : feUIDSelected;
 						if(expandUID != "*")
 							StringMacros::getSetFromString(expandUID, feUIDs);
 						else
@@ -577,10 +582,11 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 							}
 						}
 						if(feUIDs.empty())
-							feUIDs.emplace(feUIDSelected);  // fallback to existing error behavior
+							feUIDs.emplace(
+							    feUIDSelected);  // fallback to existing error behavior
 					}
 
-					auto group                     = std::make_shared<runFEMacroGroupStruct>();
+					auto group = std::make_shared<runFEMacroGroupStruct>();
 					group->historyFeClassSelected_ =
 					    feClassSelected.empty() ? "*" : feClassSelected;
 					group->historyFeUIDSelected_ =
@@ -593,17 +599,17 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					group->historyUsername_    = username;
 
 					for(const std::string& uid : feUIDs)
-						group->tasks_.push_back(std::make_shared<runFEMacroStruct>(
-						    xmldoc,
-						    feClassSelected,
-						    uid,
-						    macroType,
-						    macroName,
-						    inputArgs,
-						    outputArgs,
-						    saveOutputs,
-						    username,
-						    userGroupPermission));
+						group->tasks_.push_back(
+						    std::make_shared<runFEMacroStruct>(xmldoc,
+						                                       feClassSelected,
+						                                       uid,
+						                                       macroType,
+						                                       macroName,
+						                                       inputArgs,
+						                                       outputArgs,
+						                                       saveOutputs,
+						                                       username,
+						                                       userGroupPermission));
 
 					{
 						std::lock_guard<std::mutex> lock(
@@ -615,7 +621,8 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 						for(auto& task : group->tasks_)
 						{
 							task->bar_ = std::make_unique<ProgressBar>();
-							task->bar_->reset(macroName, task->parameters_.feUIDSelected_);
+							task->bar_->reset(macroName,
+							                  task->parameters_.feUIDSelected_);
 						}
 						theSupervisor->feMacroRunThreadStruct_.emplace_back(group);
 					}
@@ -631,13 +638,14 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 						usleep(100 * 1000);  // poll at 100 ms
 
 						auto now = std::chrono::steady_clock::now();
-						if(std::chrono::duration_cast<std::chrono::seconds>(now - lastProgressSend)
+						if(std::chrono::duration_cast<std::chrono::seconds>(
+						       now - lastProgressSend)
 						       .count() >= 2)
 						{
 							lastProgressSend = now;
 
 							int totalProgress = 0;
-							int taskCount      = 0;
+							int taskCount     = 0;
 							{
 								std::lock_guard<std::mutex> lock(
 								    theSupervisor->feMacroRunThreadStructMutex_);
@@ -651,15 +659,15 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 								}
 							}
 
-							int percent = (taskCount > 0) ? (totalProgress / taskCount) : 0;
+							int percent =
+							    (taskCount > 0) ? (totalProgress / taskCount) : 0;
 							if(percent >= 100)
 								percent = 99;
 
 							__COUTV__(percent);
-							sock.acknowledge(
-							    std::string("<progress>") + std::to_string(percent) +
-							        "</progress>",
-							    true /* verbose */);
+							sock.acknowledge(std::string("<progress>") +
+							                     std::to_string(percent) + "</progress>",
+							                 true /* verbose */);
 						}
 					}
 
@@ -672,8 +680,8 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 								xmldoc.addTextElementToData("Error", ss.str());
 								std::stringstream out;
 								xmldoc.outputXmlDocument((std::ostringstream*)&out,
-														false /*dispStdOut*/,
-														true /*allowWhiteSpace*/);
+								                         false /*dispStdOut*/,
+								                         true /*allowWhiteSpace*/);
 								__COUT__ << "out: " << out.str();
 								sock.acknowledge(out.str(), true /* verbose */);
 							}
@@ -685,8 +693,11 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					{
 						std::lock_guard<std::mutex> lock(
 						    theSupervisor->feMacroRunThreadStructMutex_);
-						for(size_t i = 0; i < theSupervisor->feMacroRunThreadStruct_.size(); ++i)
-							if(theSupervisor->feMacroRunThreadStruct_[i].get() == group.get())
+						for(size_t i = 0;
+						    i < theSupervisor->feMacroRunThreadStruct_.size();
+						    ++i)
+							if(theSupervisor->feMacroRunThreadStruct_[i].get() ==
+							   group.get())
 							{
 								theSupervisor->feMacroRunThreadStruct_.erase(
 								    theSupervisor->feMacroRunThreadStruct_.begin() + i);
@@ -699,7 +710,10 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 					                         false /*dispStdOut*/,
 					                         true /*allowWhiteSpace*/);
 					__COUT__ << "out: " << out.str();
-					sock.acknowledge(out.str(), true /* verbose */, 1500 /* max chunk size*/, 1000 /* inter-chunk delay us */);
+					sock.acknowledge(out.str(),
+					                 true /* verbose */,
+					                 1500 /* max chunk size*/,
+					                 1000 /* inter-chunk delay us */);
 				}
 				else
 				{

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -677,12 +677,14 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 						}
 					}
 
+					// Collect any task error before cleanup so group is always removed
+					std::string taskError;
 					for(auto& task : group->tasks_)
 					{
 						if(task->parameters_.feMacroRunError_ != "")
 						{
-							__SS__ << task->parameters_.feMacroRunError_;
-							__SS_THROW__;
+							taskError = task->parameters_.feMacroRunError_;
+							break;
 						}
 						xmldoc.copyDataChildren(task->parameters_.xmldoc_);
 					}
@@ -700,6 +702,12 @@ void MacroMakerSupervisor::RemoteControlWorkLoop(MacroMakerSupervisor* theSuperv
 								    theSupervisor->feMacroRunThreadStruct_.begin() + i);
 								break;
 							}
+					}
+
+					if(!taskError.empty())
+					{
+						__SS__ << taskError;
+						__SS_THROW__;
 					}
 
 					std::stringstream out;

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -141,7 +141,8 @@ MacroMakerSupervisor::MacroMakerSupervisor(xdaq::ApplicationStub* stub)
 		catch(...)
 		{
 			__SUP_COUT__ << "Ignoring unknown error reading OTS_MACROMAKER_UDP_PORT/"
-			                "OTS_MACROMAKER_UDP_IP env vars." << __E__;
+			                "OTS_MACROMAKER_UDP_IP env vars."
+			             << __E__;
 		}  // ignore errors
 
 		if(enableRemoteControl)

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -54,10 +54,27 @@ int makeSocket(const char* ip, int port, struct sockaddr_in& mm_ai_addr)
 		__SS_THROW__;
 	}
 
+				
 	//copy ai_addr, which is needed for sendto
 	memcpy(&mm_ai_addr, p->ai_addr, sizeof(mm_ai_addr));
 
 	freeaddrinfo(servinfo);
+
+
+	// increase socket buffer size
+	unsigned int socketReceiveBufferSize = 0x1400000;
+	if(setsockopt(sockfd,
+	              SOL_SOCKET,
+	              SO_RCVBUF,
+	              (char*)&socketReceiveBufferSize,
+	              sizeof(socketReceiveBufferSize)) < 0)
+		__COUT_ERR__ << "Failed to set socket receive size to 0x" << std::hex
+		             << socketReceiveBufferSize << std::dec
+		             << ". Attempting to revert to default." << std::endl;
+	else
+		__COUT__ << "set socket receive size to 0x" << std::hex << socketReceiveBufferSize
+		         << std::dec << "." << __E__;
+
 	return sockfd;
 }  //end makeSocket()
 
@@ -171,6 +188,10 @@ ots_mm_udp_interface::ots_mm_udp_interface(const char* mm_ip, int mm_port) : mm_
 	__COUT__ << "Constructor" << __E__;
 
 	mm_sock_ = makeSocket(mm_ip, mm_port, mm_ai_addr);  // mm_p_);
+
+	selfIPandPort_ = mm_ip;
+	selfIPandPort_ += ":";
+	selfIPandPort_ += std::to_string(mm_port);
 }  //end constructor()
 
 //==============================================================================
@@ -491,20 +512,48 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 
 	// read response ///////////////////////////////////////////////////////////
 	fullXML_ = "";  //clear just in case
-	while(receive(mm_sock_,
-	              buffer_,
-	              0 /*timeoutSeconds*/,
-	              200000 /*timeoutUSeconds*/,
-	              true /*verbose*/) == 0)
+	auto startTime = std::chrono::steady_clock::now();
+	auto lastUpdateTime = std::chrono::steady_clock::now();
+	int64_t lastWarnElapsedTime = 0;
+	while(true)
 	{
-		// __COUT__ << "Appending " << buffer_.size() << " received bytes" << __E__;
-		fullXML_ += buffer_;
-	}
+		if(receive(mm_sock_,
+				   buffer_,
+				   0 /*timeoutSeconds*/,
+				   200000 /*timeoutUSeconds*/,
+				   true /*verbose*/) == 0)
+		{
+			lastUpdateTime = std::chrono::steady_clock::now();
+			if(buffer_.find("<progress>") == 0)
+			{
+				__COUT_INFO__ << "Progress update: " << buffer_ << __E__;
+				continue;
+			}
+			fullXML_ += buffer_;
+			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
+			if(fullXML_.size() >= 10 &&
+				 fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
+				break;
+		}
+		auto currentTime = std::chrono::steady_clock::now();
+		auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
+		if(lastWarnElapsedTime != elapsed.count() && 
+			elapsed.count() > 2 && elapsed.count() % 3 == 0)
+		{
+			__COUT_WARN__ << "Still waiting for FE Macro Info response after " << elapsed.count() << " seconds... " <<
+				fullXML_.size() << " bytes received so far. " << fullXML_.substr(fullXML_.size() - 10) <<__E__;
+			lastWarnElapsedTime = elapsed.count();
+		}
 
+		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - lastUpdateTime);
+		if(elapsed.count() > 5)
+			break;
+	}
+	
 	if(fullXML_.size() == 0)
 	{
 		__SS__ << "FE Macro Info receive failed! Check that a MacroMaker Supervisor is "
-		          "running with UDP Remote Control enabled."
+		          "configured with UDP Remote Control enabled and accessible at " << selfIPandPort_ << "."
 		       << __E__;
 		__SS_THROW__;
 	}
@@ -1126,28 +1175,68 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 
 	// read response ///////////////////////////////////////////////////////////
 	std::string runXML = "";  //clear just in case
-	//give first response a long time for execution propagation to/from device, but following receives should be short because just from UDP packet splitting
-	if(receive(mm_sock_,
-	           buffer_,
-	           10 /*timeoutSeconds*/,
-	           0 /*timeoutUSeconds*/,
-	           true /*verbose*/) == 0)
+	auto startTime = std::chrono::steady_clock::now();
+	auto lastUpdateTime = std::chrono::steady_clock::now();
+	int64_t lastWarnElapsedTime = 0;
+	while(true)
 	{
-		// __COUT__ << "Appending " << buffer_.size() << " received bytes" << __E__;
-		runXML += buffer_;
-		while(receive(mm_sock_,
-		              buffer_,
-		              0 /*timeoutSeconds*/,
-		              200000 /*timeoutUSeconds*/,
-		              true /*verbose*/) == 0)
+		if(receive(mm_sock_,
+				   buffer_,
+				   0 /*timeoutSeconds*/,
+				   200000 /*timeoutUSeconds*/,
+				   true /*verbose*/) == 0)
+		{
+			lastUpdateTime = std::chrono::steady_clock::now();
+			if(buffer_.find("<progress>") == 0)
+			{
+				__COUT_INFO__ << "Progress update: " << buffer_ << __E__;
+				continue;
+			}
 			runXML += buffer_;
+			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
+			if(runXML.size() >= 10 &&
+				 runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
+				break;
+		}
+		auto currentTime = std::chrono::steady_clock::now();
+		auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
+		if(lastWarnElapsedTime != elapsed.count() && 
+			elapsed.count() > 2 && elapsed.count() % 3 == 0)
+		{
+			__COUT_WARN__ << "Still waiting for FE Macro Info response after " << elapsed.count() << " seconds... " <<
+				runXML.size() << " bytes received so far." << __E__;
+			lastWarnElapsedTime = elapsed.count();
+		}
+
+		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - lastUpdateTime);
+		if(elapsed.count() > 10)
+			break;
 	}
 
-	__COUTV__(runXML);
+	// //give first response a long time for execution propagation to/from device, but following receives should be short because just from UDP packet splitting
+	// if(receive(mm_sock_,
+	//            buffer_,
+	//            10 /*timeoutSeconds*/,
+	//            0 /*timeoutUSeconds*/,
+	//            true /*verbose*/) == 0)
+	// {
+	// 	// __COUT__ << "Appending " << buffer_.size() << " received bytes" << __E__;
+	// 	runXML += buffer_;
+	// 	while(receive(mm_sock_,
+	// 	              buffer_,
+	// 	              0 /*timeoutSeconds*/,
+	// 	              200000 /*timeoutUSeconds*/,
+	// 	              true /*verbose*/) == 0)
+	// 		runXML += buffer_;
+	// }
 
-	if(runXML.size() == 0 || runXML.find("Error") == 0)
+	// __COUTV__(runXML);
+
+	if(runXML.size() == 0 || runXML.find("Error") == 0 || 
+		(runXML.size() >= 10 &&
+				 runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
 	{
-		__SS__ << "Error running the command. Received buffer: "
+		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;
 		__SS_THROW__;
 	}

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -1,7 +1,16 @@
 
 #include "test/ots_mm_udp_interface.h"
 
+#include <chrono>
+
 #define MAXBUFLEN 5000
+
+//==============================================================================
+bool hasCompleteXmlRoot(const std::string& xml)
+{
+	return xml.size() >= 10 &&
+	       xml.substr(xml.size() - 10).find("</ROOT>") != std::string::npos;
+} //end hasCompleteXmlRoot()
 
 //==============================================================================
 /// get sockaddr, IPv4 or IPv6:
@@ -202,6 +211,56 @@ ots_mm_udp_interface::~ots_mm_udp_interface()
 	// if(mm_servinfo_)
 	// 	freeaddrinfo(mm_servinfo_);
 }  //end destructor()
+
+//==============================================================================
+void ots_mm_udp_interface::receiveXmlResponse(std::string&       response,
+	                                          const std::string& waitDescription,
+	                                          int                inactivityTimeoutSeconds)
+{
+	response.clear();
+	auto    startTime           = std::chrono::steady_clock::now();
+	auto    lastUpdateTime      = std::chrono::steady_clock::now();
+	int64_t lastWarnElapsedTime = 0;
+
+	while(true)
+	{
+		if(receive(mm_sock_,
+		           buffer_,
+		           0 /*timeoutSeconds*/,
+		           200000 /*timeoutUSeconds*/,
+		           false /*verbose*/) == 0)
+		{
+			lastUpdateTime = std::chrono::steady_clock::now();
+			if(buffer_.find("<progress>") == 0)
+			{
+				__COUT_INFO__ << "Progress update: " << buffer_ << __E__;
+				continue;
+			}
+
+			response += buffer_;
+			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
+			if(hasCompleteXmlRoot(response))
+				break;
+		}
+
+		auto currentTime = std::chrono::steady_clock::now();
+		auto elapsed =
+		    std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
+		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
+		   elapsed.count() % 3 == 0)
+		{
+			__COUT_WARN__ << "Still waiting for " << waitDescription << " after "
+			              << elapsed.count() << " seconds... " << response.size()
+			              << " bytes received so far." << __E__;
+			lastWarnElapsedTime = elapsed.count();
+		}
+
+		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime -
+		                                                           lastUpdateTime);
+		if(elapsed.count() > inactivityTimeoutSeconds)
+			break;
+	}
+} //end receiveXmlResponse()
 
 //=========================================================================
 ///extract value for field from xml looking forwards from after
@@ -508,47 +567,7 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 	// __COUTV__(numbytes);
 
 	// read response ///////////////////////////////////////////////////////////
-	fullXML_                    = "";  //clear just in case
-	auto    startTime           = std::chrono::steady_clock::now();
-	auto    lastUpdateTime      = std::chrono::steady_clock::now();
-	int64_t lastWarnElapsedTime = 0;
-	while(true)
-	{
-		if(receive(mm_sock_,
-		           buffer_,
-		           0 /*timeoutSeconds*/,
-		           200000 /*timeoutUSeconds*/,
-		           false /*verbose*/) == 0)
-		{
-			lastUpdateTime = std::chrono::steady_clock::now();
-			if(buffer_.find("<progress>") == 0)
-			{
-				__COUT_INFO__ << "Progress update: " << buffer_ << __E__;
-				continue;
-			}
-			fullXML_ += buffer_;
-			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(fullXML_.size() >= 10 &&
-			   fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
-				break;
-		}
-		auto currentTime = std::chrono::steady_clock::now();
-		auto elapsed =
-		    std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
-		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
-		   elapsed.count() % 3 == 0)
-		{
-			__COUT_WARN__ << "Still waiting for FE Macro Info response after "
-			              << elapsed.count() << " seconds... " << fullXML_.size()
-			              << " bytes received so far." << __E__;
-			lastWarnElapsedTime = elapsed.count();
-		}
-
-		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime -
-		                                                           lastUpdateTime);
-		if(elapsed.count() > 5)
-			break;
-	}
+	receiveXmlResponse(fullXML_, "FE Macro Info response", 5);
 
 	if(fullXML_.size() == 0)
 	{
@@ -1174,52 +1193,12 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 	}
 
 	// read response ///////////////////////////////////////////////////////////
-	std::string runXML              = "";  //clear just in case
-	auto        startTime           = std::chrono::steady_clock::now();
-	auto        lastUpdateTime      = std::chrono::steady_clock::now();
-	int64_t     lastWarnElapsedTime = 0;
-	while(true)
-	{
-		if(receive(mm_sock_,
-		           buffer_,
-		           0 /*timeoutSeconds*/,
-		           200000 /*timeoutUSeconds*/,
-		           false /*verbose*/) == 0)
-		{
-			lastUpdateTime = std::chrono::steady_clock::now();
-			if(buffer_.find("<progress>") == 0)
-			{
-				__COUT_INFO__ << "Progress update: " << buffer_ << __E__;
-				continue;
-			}
-			runXML += buffer_;
-			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(runXML.size() >= 10 &&
-			   runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
-				break;
-		}
-		auto currentTime = std::chrono::steady_clock::now();
-		auto elapsed =
-		    std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
-		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
-		   elapsed.count() % 3 == 0)
-		{
-			__COUT_WARN__ << "Still waiting for command run response after "
-			              << elapsed.count() << " seconds... " << runXML.size()
-			              << " bytes received so far." << __E__;
-			lastWarnElapsedTime = elapsed.count();
-		}
-
-		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime -
-		                                                           lastUpdateTime);
-		if(elapsed.count() > 10)
-			break;
-	}
+	std::string runXML;
+	receiveXmlResponse(runXML, "command run response", 10);
 
 	// At this point, runXML should contain the complete response assembled by the current receive logic.
 	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
-	   (runXML.size() >= 10 &&
-	    runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
+	   !hasCompleteXmlRoot(runXML))
 	{
 		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -541,8 +541,7 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 		{
 			__COUT_WARN__ << "Still waiting for FE Macro Info response after "
 			              << elapsed.count() << " seconds... " << fullXML_.size()
-			              << " bytes received so far. "
-			              << fullXML_.substr(fullXML_.size() - 10) << __E__;
+			              << " bytes received so far." << __E__;
 			lastWarnElapsedTime = elapsed.count();
 		}
 

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -54,12 +54,10 @@ int makeSocket(const char* ip, int port, struct sockaddr_in& mm_ai_addr)
 		__SS_THROW__;
 	}
 
-				
 	//copy ai_addr, which is needed for sendto
 	memcpy(&mm_ai_addr, p->ai_addr, sizeof(mm_ai_addr));
 
 	freeaddrinfo(servinfo);
-
 
 	// increase socket buffer size
 	unsigned int socketReceiveBufferSize = 0x1400000;
@@ -511,17 +509,17 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 	// __COUTV__(numbytes);
 
 	// read response ///////////////////////////////////////////////////////////
-	fullXML_ = "";  //clear just in case
-	auto startTime = std::chrono::steady_clock::now();
-	auto lastUpdateTime = std::chrono::steady_clock::now();
+	fullXML_                    = "";  //clear just in case
+	auto    startTime           = std::chrono::steady_clock::now();
+	auto    lastUpdateTime      = std::chrono::steady_clock::now();
 	int64_t lastWarnElapsedTime = 0;
 	while(true)
 	{
 		if(receive(mm_sock_,
-				   buffer_,
-				   0 /*timeoutSeconds*/,
-				   200000 /*timeoutUSeconds*/,
-				   true /*verbose*/) == 0)
+		           buffer_,
+		           0 /*timeoutSeconds*/,
+		           200000 /*timeoutUSeconds*/,
+		           true /*verbose*/) == 0)
 		{
 			lastUpdateTime = std::chrono::steady_clock::now();
 			if(buffer_.find("<progress>") == 0)
@@ -532,29 +530,33 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 			fullXML_ += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
 			if(fullXML_.size() >= 10 &&
-				 fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
+			   fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
-		auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
-		if(lastWarnElapsedTime != elapsed.count() && 
-			elapsed.count() > 2 && elapsed.count() % 3 == 0)
+		auto elapsed =
+		    std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
+		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
+		   elapsed.count() % 3 == 0)
 		{
-			__COUT_WARN__ << "Still waiting for FE Macro Info response after " << elapsed.count() << " seconds... " <<
-				fullXML_.size() << " bytes received so far. " << fullXML_.substr(fullXML_.size() - 10) <<__E__;
+			__COUT_WARN__ << "Still waiting for FE Macro Info response after "
+			              << elapsed.count() << " seconds... " << fullXML_.size()
+			              << " bytes received so far. "
+			              << fullXML_.substr(fullXML_.size() - 10) << __E__;
 			lastWarnElapsedTime = elapsed.count();
 		}
 
-		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - lastUpdateTime);
+		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime -
+		                                                           lastUpdateTime);
 		if(elapsed.count() > 5)
 			break;
 	}
-	
+
 	if(fullXML_.size() == 0)
 	{
 		__SS__ << "FE Macro Info receive failed! Check that a MacroMaker Supervisor is "
-		          "configured with UDP Remote Control enabled and accessible at " << selfIPandPort_ << "."
-		       << __E__;
+		          "configured with UDP Remote Control enabled and accessible at "
+		       << selfIPandPort_ << "." << __E__;
 		__SS_THROW__;
 	}
 
@@ -1174,17 +1176,17 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 	}
 
 	// read response ///////////////////////////////////////////////////////////
-	std::string runXML = "";  //clear just in case
-	auto startTime = std::chrono::steady_clock::now();
-	auto lastUpdateTime = std::chrono::steady_clock::now();
-	int64_t lastWarnElapsedTime = 0;
+	std::string runXML              = "";  //clear just in case
+	auto        startTime           = std::chrono::steady_clock::now();
+	auto        lastUpdateTime      = std::chrono::steady_clock::now();
+	int64_t     lastWarnElapsedTime = 0;
 	while(true)
 	{
 		if(receive(mm_sock_,
-				   buffer_,
-				   0 /*timeoutSeconds*/,
-				   200000 /*timeoutUSeconds*/,
-				   true /*verbose*/) == 0)
+		           buffer_,
+		           0 /*timeoutSeconds*/,
+		           200000 /*timeoutUSeconds*/,
+		           true /*verbose*/) == 0)
 		{
 			lastUpdateTime = std::chrono::steady_clock::now();
 			if(buffer_.find("<progress>") == 0)
@@ -1195,20 +1197,23 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 			runXML += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
 			if(runXML.size() >= 10 &&
-				 runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
+			   runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
-		auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
-		if(lastWarnElapsedTime != elapsed.count() && 
-			elapsed.count() > 2 && elapsed.count() % 3 == 0)
+		auto elapsed =
+		    std::chrono::duration_cast<std::chrono::seconds>(currentTime - startTime);
+		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
+		   elapsed.count() % 3 == 0)
 		{
-			__COUT_WARN__ << "Still waiting for FE Macro Info response after " << elapsed.count() << " seconds... " <<
-				runXML.size() << " bytes received so far." << __E__;
+			__COUT_WARN__ << "Still waiting for FE Macro Info response after "
+			              << elapsed.count() << " seconds... " << runXML.size()
+			              << " bytes received so far." << __E__;
 			lastWarnElapsedTime = elapsed.count();
 		}
 
-		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime - lastUpdateTime);
+		elapsed = std::chrono::duration_cast<std::chrono::seconds>(currentTime -
+		                                                           lastUpdateTime);
 		if(elapsed.count() > 10)
 			break;
 	}
@@ -1232,9 +1237,9 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 
 	// __COUTV__(runXML);
 
-	if(runXML.size() == 0 || runXML.find("Error") == 0 || 
-		(runXML.size() >= 10 &&
-				 runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
+	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
+	   (runXML.size() >= 10 &&
+	    runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
 	{
 		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -1216,25 +1216,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 			break;
 	}
 
-	// //give first response a long time for execution propagation to/from device, but following receives should be short because just from UDP packet splitting
-	// if(receive(mm_sock_,
-	//            buffer_,
-	//            10 /*timeoutSeconds*/,
-	//            0 /*timeoutUSeconds*/,
-	//            true /*verbose*/) == 0)
-	// {
-	// 	// __COUT__ << "Appending " << buffer_.size() << " received bytes" << __E__;
-	// 	runXML += buffer_;
-	// 	while(receive(mm_sock_,
-	// 	              buffer_,
-	// 	              0 /*timeoutSeconds*/,
-	// 	              200000 /*timeoutUSeconds*/,
-	// 	              true /*verbose*/) == 0)
-	// 		runXML += buffer_;
-	// }
-
-	// __COUTV__(runXML);
-
+	// At this point, runXML should contain the complete response assembled by the current receive logic.
 	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
 	   (runXML.size() >= 10 &&
 	    runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -67,8 +67,7 @@ int makeSocket(const char* ip, int port, struct sockaddr_in& mm_ai_addr)
 	              (char*)&socketReceiveBufferSize,
 	              sizeof(socketReceiveBufferSize)) < 0)
 		__COUT_ERR__ << "Failed to set socket receive size to 0x" << std::hex
-		             << socketReceiveBufferSize << std::dec
-		             << ". Attempting to revert to default." << std::endl;
+		             << socketReceiveBufferSize << std::dec << "." << std::endl;
 	else
 		__COUT__ << "set socket receive size to 0x" << std::hex << socketReceiveBufferSize
 		         << std::dec << "." << __E__;

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -1184,7 +1184,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 		           buffer_,
 		           0 /*timeoutSeconds*/,
 		           200000 /*timeoutUSeconds*/,
-		           true /*verbose*/) == 0)
+		           false /*verbose*/) == 0)
 		{
 			lastUpdateTime = std::chrono::steady_clock::now();
 			if(buffer_.find("<progress>") == 0)

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -528,8 +528,7 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 			}
 			fullXML_ += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(fullXML_.size() >= 10 &&
-			   fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
+			if(fullXML_.find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
@@ -1194,8 +1193,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 			}
 			runXML += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(runXML.size() >= 10 &&
-			   runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
+			if(runXML.find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
@@ -1236,8 +1234,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 	// __COUTV__(runXML);
 
 	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
-	   (runXML.size() >= 10 &&
-	    runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
+	   runXML.find("</ROOT>") == std::string::npos)
 	{
 		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -518,7 +518,7 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 		           buffer_,
 		           0 /*timeoutSeconds*/,
 		           200000 /*timeoutUSeconds*/,
-		           true /*verbose*/) == 0)
+		           false /*verbose*/) == 0)
 		{
 			lastUpdateTime = std::chrono::steady_clock::now();
 			if(buffer_.find("<progress>") == 0)

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -528,7 +528,8 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 			}
 			fullXML_ += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(fullXML_.find("</ROOT>") != std::string::npos)
+			if(fullXML_.size() >= 10 &&
+			   fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
@@ -1193,7 +1194,8 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 			}
 			runXML += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(runXML.find("</ROOT>") != std::string::npos)
+			if(runXML.size() >= 10 &&
+			   runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -1205,7 +1205,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 		if(lastWarnElapsedTime != elapsed.count() && elapsed.count() > 2 &&
 		   elapsed.count() % 3 == 0)
 		{
-			__COUT_WARN__ << "Still waiting for FE Macro Info response after "
+			__COUT_WARN__ << "Still waiting for command run response after "
 			              << elapsed.count() << " seconds... " << runXML.size()
 			              << " bytes received so far." << __E__;
 			lastWarnElapsedTime = elapsed.count();

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -528,7 +528,8 @@ const std::string& ots_mm_udp_interface::getFrontendMacroInfo()
 			}
 			fullXML_ += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(fullXML_.find("</ROOT>") != std::string::npos)
+			if(fullXML_.size() >= 10 &&
+			   fullXML_.substr(fullXML_.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
@@ -1193,7 +1194,8 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 			}
 			runXML += buffer_;
 			// __COUT_INFO__ << "Received: " << buffer_ << __E__;
-			if(runXML.find("</ROOT>") != std::string::npos)
+			if(runXML.size() >= 10 &&
+			   runXML.substr(runXML.size() - 10).find("</ROOT>") != std::string::npos)
 				break;
 		}
 		auto currentTime = std::chrono::steady_clock::now();
@@ -1234,7 +1236,8 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 	// __COUTV__(runXML);
 
 	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
-	   runXML.find("</ROOT>") == std::string::npos)
+	   (runXML.size() >= 10 &&
+	    runXML.substr(runXML.size() - 10).find("</ROOT>") == std::string::npos))
 	{
 		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;

--- a/test/ots_mm_udp_interface.cpp
+++ b/test/ots_mm_udp_interface.cpp
@@ -10,7 +10,7 @@ bool hasCompleteXmlRoot(const std::string& xml)
 {
 	return xml.size() >= 10 &&
 	       xml.substr(xml.size() - 10).find("</ROOT>") != std::string::npos;
-} //end hasCompleteXmlRoot()
+}  //end hasCompleteXmlRoot()
 
 //==============================================================================
 /// get sockaddr, IPv4 or IPv6:
@@ -214,8 +214,8 @@ ots_mm_udp_interface::~ots_mm_udp_interface()
 
 //==============================================================================
 void ots_mm_udp_interface::receiveXmlResponse(std::string&       response,
-	                                          const std::string& waitDescription,
-	                                          int                inactivityTimeoutSeconds)
+                                              const std::string& waitDescription,
+                                              int                inactivityTimeoutSeconds)
 {
 	response.clear();
 	auto    startTime           = std::chrono::steady_clock::now();
@@ -260,7 +260,7 @@ void ots_mm_udp_interface::receiveXmlResponse(std::string&       response,
 		if(elapsed.count() > inactivityTimeoutSeconds)
 			break;
 	}
-} //end receiveXmlResponse()
+}  //end receiveXmlResponse()
 
 //=========================================================================
 ///extract value for field from xml looking forwards from after
@@ -1197,8 +1197,7 @@ std::string ots_mm_udp_interface::runCommand(const std::string& targetFE,
 	receiveXmlResponse(runXML, "command run response", 10);
 
 	// At this point, runXML should contain the complete response assembled by the current receive logic.
-	if(runXML.size() == 0 || runXML.find("Error") == 0 ||
-	   !hasCompleteXmlRoot(runXML))
+	if(runXML.size() == 0 || runXML.find("Error") == 0 || !hasCompleteXmlRoot(runXML))
 	{
 		__SS__ << "Error running the command. Received error or incomplete buffer: "
 		       << (runXML.size() == 0 ? "<empty>" : runXML) << __E__;

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -108,8 +108,8 @@ class ots_mm_udp_interface
 
   private:
 	void               receiveXmlResponse(std::string&       response,
-	                                    const std::string& waitDescription,
-	                                    int                inactivityTimeoutSeconds);
+	                                      const std::string& waitDescription,
+	                                      int                inactivityTimeoutSeconds);
 	int                mm_sock_;
 	struct sockaddr_in mm_ai_addr;
 	std::string        buffer_;

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -111,7 +111,7 @@ class ots_mm_udp_interface
 	struct sockaddr_in mm_ai_addr;
 	std::string        buffer_;
 	std::string        fullXML_;
-	std::string        selfIPandPort_;  //cache of this info for error messages, etc.
+	std::string        selfIPandPort_;  // cache of the MacroMaker server IP and port (mm_ip:mm_port) for error messages, etc.
 	                                    ///Note: if std::map does not complicate interface too much for ROOT/python, could make member functions return const std::string& and leverage cache solution
 	                                    /// std::map<std::string /*fe+cmd*/,std::map<std::string /*field*/, std::string /*value*/>> feCache_;
 	                                    ///

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -107,6 +107,9 @@ class ots_mm_udp_interface
 	static std::string decodeHTMLEntities(const std::string& data);
 
   private:
+	void               receiveXmlResponse(std::string&       response,
+	                                    const std::string& waitDescription,
+	                                    int                inactivityTimeoutSeconds);
 	int                mm_sock_;
 	struct sockaddr_in mm_ai_addr;
 	std::string        buffer_;

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -113,7 +113,7 @@ class ots_mm_udp_interface
 	std::string        buffer_;
 	std::string        fullXML_;
 	std::string        selfIPandPort_;  //cache of this info for error messages, etc.
-	                                    ///Note: if std::map does not complicate interface too much for ROOT/pyton, could make member functions return const std::string& and leverage cache solution
+	                                    ///Note: if std::map does not complicate interface too much for ROOT/python, could make member functions return const std::string& and leverage cache solution
 	                                    /// std::map<std::string /*fe+cmd*/,std::map<std::string /*field*/, std::string /*value*/>> feCache_;
 	                                    ///
 };                                      //end ots_mm_udp_interface class declaration

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -14,7 +14,6 @@
 #include <unistd.h>
 
 #include <string.h>  //for strstr (not the same as <string>)
-#include <chrono>
 #include <iostream>
 #include <map>
 #include <set>

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -14,13 +14,13 @@
 #include <unistd.h>
 
 #include <string.h>  //for strstr (not the same as <string>)
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <set>
 #include <sstream>
 #include <string>  //for string
 #include <vector>
-#include <chrono>
 
 #define __COUT_HDR__ ""
 
@@ -112,10 +112,10 @@ class ots_mm_udp_interface
 	struct sockaddr_in mm_ai_addr;
 	std::string        buffer_;
 	std::string        fullXML_;
-	std::string		   selfIPandPort_;  //cache of this info for error messages, etc.
-	///Note: if std::map does not complicate interface too much for ROOT/pyton, could make member functions return const std::string& and leverage cache solution
-	/// std::map<std::string /*fe+cmd*/,std::map<std::string /*field*/, std::string /*value*/>> feCache_;
-	///
-};  //end ots_mm_udp_interface class declaration
+	std::string        selfIPandPort_;  //cache of this info for error messages, etc.
+	                                    ///Note: if std::map does not complicate interface too much for ROOT/pyton, could make member functions return const std::string& and leverage cache solution
+	                                    /// std::map<std::string /*fe+cmd*/,std::map<std::string /*field*/, std::string /*value*/>> feCache_;
+	                                    ///
+};                                      //end ots_mm_udp_interface class declaration
 
 #endif

--- a/test/ots_mm_udp_interface.h
+++ b/test/ots_mm_udp_interface.h
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <string>  //for string
 #include <vector>
+#include <chrono>
 
 #define __COUT_HDR__ ""
 
@@ -111,6 +112,7 @@ class ots_mm_udp_interface
 	struct sockaddr_in mm_ai_addr;
 	std::string        buffer_;
 	std::string        fullXML_;
+	std::string		   selfIPandPort_;  //cache of this info for error messages, etc.
 	///Note: if std::map does not complicate interface too much for ROOT/pyton, could make member functions return const std::string& and leverage cache solution
 	/// std::map<std::string /*fe+cmd*/,std::map<std::string /*field*/, std::string /*value*/>> feCache_;
 	///

--- a/test/ots_mm_udp_test.cpp
+++ b/test/ots_mm_udp_test.cpp
@@ -41,10 +41,10 @@ try
 	std::vector<std::string> fes = getVectorFromString(feStr, {';'});
 	if(fes.size() == 0 || (fes.size() == 1 && fes[0] == ""))
 	{
-		__COUT_ERR__ << "No Front-ends found in FE list! Check that a MacroMaker Supervisor is "
-		             << "configured with UDP Remote Control enabled and accessible at " << 
-					 target_mm_ip << ":" << target_mm_port << "."
-		             << __E__;
+		__COUT_ERR__
+		    << "No Front-ends found in FE list! Check that a MacroMaker Supervisor is "
+		    << "configured with UDP Remote Control enabled and accessible at "
+		    << target_mm_ip << ":" << target_mm_port << "." << __E__;
 		return 0;
 	}
 
@@ -61,7 +61,7 @@ try
 		if(fe >= fes.size())
 		{
 			__COUT_ERR__ << "Illegal front-end UID " << target_fe
-			             << " not found in FE list: " << vectorToString(fes, {';'}) << "."			
+			             << " not found in FE list: " << vectorToString(fes, {';'}) << "."
 			             << __E__;
 			return 0;
 		}
@@ -109,8 +109,8 @@ try
 	else
 	{
 		__COUT_INFO__ << "No FE Macro Name specified, here is the list of existing FE "
-		                "Macro Names corresponding to the specified Front-end UID '"
-		             << argv[3] << "':" << __E__;
+		                 "Macro Names corresponding to the specified Front-end UID '"
+		              << argv[3] << "':" << __E__;
 		for(cmd = 0; cmd < commands.size(); ++cmd)
 			__COUT_INFO__ << "\t\t" << commands[cmd] << __E__;
 

--- a/test/ots_mm_udp_test.cpp
+++ b/test/ots_mm_udp_test.cpp
@@ -45,7 +45,7 @@ try
 		    << "No Front-ends found in FE list! Check that a MacroMaker Supervisor is "
 		    << "configured with UDP Remote Control enabled and accessible at "
 		    << target_mm_ip << ":" << target_mm_port << "." << __E__;
-		return 0;
+		return 1;
 	}
 
 	uint32_t fe  = -1;
@@ -63,7 +63,7 @@ try
 			__COUT_ERR__ << "Illegal front-end UID " << target_fe
 			             << " not found in FE list: " << vectorToString(fes, {';'}) << "."
 			             << __E__;
-			return 0;
+			return 1;
 		}
 	}
 	else
@@ -81,7 +81,7 @@ try
 	{
 		__COUT_ERR__ << "Illegal front-end index " << fe << " vs " << fes.size()
 		             << " count." << __E__;
-		return 0;
+		return 1;
 	}
 
 	__COUTV__(fes[fe]);
@@ -103,7 +103,7 @@ try
 			             << "' not found in '" << fes[fe]
 			             << "' Command list: " << vectorToString(commands, {';'}) << "."
 			             << __E__;
-			return 0;
+			return 1;
 		}
 	}
 	else
@@ -121,7 +121,7 @@ try
 	{
 		__COUT_ERR__ << "Illegal command index " << cmd << " vs " << commands.size()
 		             << " count." << __E__;
-		return 0;
+		return 1;
 	}
 
 	__COUTV__(commands[cmd]);
@@ -176,7 +176,7 @@ try
 		__COUT_ERR__ << "Illegal response, mismatch in output arguments returned: "
 		             << outputs.size() << " vs " << numberOfOutputs << " expected."
 		             << __E__;
-		return 0;
+		return 1;
 	}
 
 	__COUTV__(vectorToString(outputs, {';'}));

--- a/test/ots_mm_udp_test.cpp
+++ b/test/ots_mm_udp_test.cpp
@@ -154,9 +154,8 @@ try
 	{
 		inputs.push_back(ots_mm_udp_interface::encodeURIComponent(argv[5 + i]));
 		std::string inputName = mm.getCommandInputName(fes[fe], commands[cmd], i);
-		__COUT_INFO__ << "\tInput #" << i << ": " << inputName << " = " << 
-					ots_mm_udp_interface::decodeURIComponent(inputs.back())
-		              << __E__;
+		__COUT_INFO__ << "\tInput #" << i << ": " << inputName << " = "
+		              << ots_mm_udp_interface::decodeURIComponent(inputs.back()) << __E__;
 	}
 
 	__COUT_INFO__ << "Running command with these expected outputs..." << __E__;

--- a/test/ots_mm_udp_test.cpp
+++ b/test/ots_mm_udp_test.cpp
@@ -39,6 +39,14 @@ try
 	std::string feStr = mm.getFrontendList();
 	__COUTV__(feStr);
 	std::vector<std::string> fes = getVectorFromString(feStr, {';'});
+	if(fes.size() == 0 || (fes.size() == 1 && fes[0] == ""))
+	{
+		__COUT_ERR__ << "No Front-ends found in FE list! Check that a MacroMaker Supervisor is "
+		             << "configured with UDP Remote Control enabled and accessible at " << 
+					 target_mm_ip << ":" << target_mm_port << "."
+		             << __E__;
+		return 0;
+	}
 
 	uint32_t fe  = -1;
 	uint32_t cmd = -1;
@@ -53,18 +61,18 @@ try
 		if(fe >= fes.size())
 		{
 			__COUT_ERR__ << "Illegal front-end UID " << target_fe
-			             << " not found in FE list: " << vectorToString(fes, {';'}) << "."
+			             << " not found in FE list: " << vectorToString(fes, {';'}) << "."			
 			             << __E__;
 			return 0;
 		}
 	}
 	else
 	{
-		__COUT_ERR__
+		__COUT_INFO__
 		    << "No front-end UID specified, here is the list of existing Front-end UIDs:"
 		    << __E__;
 		for(fe = 0; fe < fes.size(); ++fe)
-			__COUT_ERR__ << "\t\t" << fes[fe] << __E__;
+			__COUT_INFO__ << "\t\t" << fes[fe] << __E__;
 
 		return 0;
 	}
@@ -100,11 +108,11 @@ try
 	}
 	else
 	{
-		__COUT_ERR__ << "No FE Macro Name specified, here is the list of existing FE "
+		__COUT_INFO__ << "No FE Macro Name specified, here is the list of existing FE "
 		                "Macro Names corresponding to the specified Front-end UID '"
 		             << argv[3] << "':" << __E__;
 		for(cmd = 0; cmd < commands.size(); ++cmd)
-			__COUT_ERR__ << "\t\t" << commands[cmd] << __E__;
+			__COUT_INFO__ << "\t\t" << commands[cmd] << __E__;
 
 		return 0;
 	}

--- a/test/ots_mm_udp_test.cpp
+++ b/test/ots_mm_udp_test.cpp
@@ -154,7 +154,8 @@ try
 	{
 		inputs.push_back(ots_mm_udp_interface::encodeURIComponent(argv[5 + i]));
 		std::string inputName = mm.getCommandInputName(fes[fe], commands[cmd], i);
-		__COUT_INFO__ << "\tInput #" << i << ": " << inputName << " = " << inputs.back()
+		__COUT_INFO__ << "\tInput #" << i << ": " << inputName << " = " << 
+					ots_mm_udp_interface::decodeURIComponent(inputs.back())
 		              << __E__;
 	}
 


### PR DESCRIPTION
- [x] Remove `fullXML_.substr(fullXML_.size() - 10)` tail debug printout from warning log
- [x] Revert commit `594d1f7` (restore `substr`-based `</ROOT>` detection in receive loops)

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.