### PR TITLE
Macromaker mode over 300s was working, but in normal mode there was a…

### DIFF
--- a/WebGUI/css/SubsystemLaunch.css
+++ b/WebGUI/css/SubsystemLaunch.css
@@ -221,6 +221,11 @@
 			cursor: pointer;
 		}
 
+		#subsystemDiv .tableDoubleRowMode .subsystem_name {
+			font-size: 13px;
+			font-weight: bold;
+		}
+
 		.subsystem_detail {
 			font-size: 14px;
 			text-align: left;

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -3366,7 +3366,13 @@ try
 				}
 				else
 				{
-					if(task->bar_)
+					int rp = task->realProgress_.load();
+					if(rp >= 0)
+					{
+						xmldoc.addTextElementToParent(
+						    "progress", std::to_string(rp), progParent);
+					}
+					else if(task->bar_)
 					{
 						xmldoc.addTextElementToParent(
 						    "progress", std::to_string(task->bar_->read()), progParent);
@@ -3505,7 +3511,13 @@ try
 				}
 				else
 				{
-					if(task->bar_)
+					int rp = task->realProgress_.load();
+					if(rp >= 0)
+					{
+						xmldoc.addTextElementToParent(
+						    "progress", std::to_string(rp), progParent);
+					}
+					else if(task->bar_)
 					{
 						xmldoc.addTextElementToParent(
 						    "progress", std::to_string(task->bar_->read()), progParent);
@@ -3700,7 +3712,8 @@ try
 	                         feMacroRunThreadStruct->parameters_.saveOutputs_,
 	                         feMacroRunThreadStruct->parameters_.runningUsername_,
 	                         feMacroRunThreadStruct->parameters_.userGroupPermissions_,
-	                         false /* saveToHistory */);
+	                         false /* saveToHistory */,
+	                         &feMacroRunThreadStruct->realProgress_);
 
 	feMacroRunThreadStruct->parameters_.doneTime_ = time(0);
 	feMacroRunThreadStruct->feMacroRunDone_       = true;
@@ -3747,7 +3760,8 @@ void MacroMakerSupervisor::runFEMacro(HttpXmlDocument&   xmldoc,
                                       bool               saveOutputs,
                                       const std::string& username,
                                       const std::string& userGroupPermissions,
-                                      bool               saveToHistory)
+                                      bool               saveToHistory,
+                                      std::atomic<int>*  realProgressOut)
 {
 	__SUP_COUTV__(feClassSelected);
 	__SUP_COUTV__(feUIDSelected);
@@ -3906,11 +3920,13 @@ void MacroMakerSupervisor::runFEMacro(HttpXmlDocument&   xmldoc,
 			txParameters.addParameter("inputArgs", inputArgs);
 			txParameters.addParameter("outputArgs", outputArgs);
 			txParameters.addParameter("userPermissions", userGroupPermissions);
+			txParameters.addParameter("AsyncSupported", "1");
 
 			SOAPParameters rxParameters;  // params for xoap to recv
 			// rxParameters.addParameter("success");
 			rxParameters.addParameter("outputArgs");
 			rxParameters.addParameter("Error");
+			rxParameters.addParameter("NotDoneTaskID");
 
 			if(saveOutputs)
 			{
@@ -3939,6 +3955,46 @@ void MacroMakerSupervisor::runFEMacro(HttpXmlDocument&   xmldoc,
 			SOAPUtilities::receive(retMsg, rxParameters);
 
 			__SUP_COUT__ << "Received it " << __E__;
+
+			// If FESupervisor returned NotDoneTaskID, poll until macro completes
+			{
+				std::string notDoneTaskID = rxParameters.getValue("NotDoneTaskID");
+				while(notDoneTaskID != "")
+				{
+					__SUP_COUT__ << "FE Macro async task " << notDoneTaskID
+					             << " still running for FE '" << feUID
+					             << "'. Polling in 5s..." << __E__;
+					sleep(5);
+
+					SOAPParameters pollTxParams;
+					pollTxParams.addParameter("Request", "CheckMacro");
+					pollTxParams.addParameter("TaskID", notDoneTaskID);
+
+					xoap::MessageReference pollRetMsg =
+					    SOAPMessenger::sendWithSOAPReply(
+					        it->second.getDescriptor(),
+					        "MacroMakerSupervisorRequest",
+					        pollTxParams);
+
+					rxParameters = SOAPParameters();
+					rxParameters.addParameter("outputArgs");
+					rxParameters.addParameter("Error");
+					rxParameters.addParameter("NotDoneTaskID");
+					rxParameters.addParameter("Progress");
+					SOAPUtilities::receive(pollRetMsg, rxParameters);
+
+					// Update real progress if FESupervisor reported it
+					if(realProgressOut)
+					{
+						std::string progressStr =
+						    rxParameters.getValue("Progress");
+						if(!progressStr.empty())
+							realProgressOut->store(std::stoi(progressStr));
+					}
+
+					notDoneTaskID = rxParameters.getValue("NotDoneTaskID");
+				}
+			}
 
 			// bool success = rxParameters.getValue("success") == "1";
 			std::string outputResults = rxParameters.getValue("outputArgs");

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.cc
@@ -3971,10 +3971,9 @@ void MacroMakerSupervisor::runFEMacro(HttpXmlDocument&   xmldoc,
 					pollTxParams.addParameter("TaskID", notDoneTaskID);
 
 					xoap::MessageReference pollRetMsg =
-					    SOAPMessenger::sendWithSOAPReply(
-					        it->second.getDescriptor(),
-					        "MacroMakerSupervisorRequest",
-					        pollTxParams);
+					    SOAPMessenger::sendWithSOAPReply(it->second.getDescriptor(),
+					                                     "MacroMakerSupervisorRequest",
+					                                     pollTxParams);
 
 					rxParameters = SOAPParameters();
 					rxParameters.addParameter("outputArgs");
@@ -3986,8 +3985,7 @@ void MacroMakerSupervisor::runFEMacro(HttpXmlDocument&   xmldoc,
 					// Update real progress if FESupervisor reported it
 					if(realProgressOut)
 					{
-						std::string progressStr =
-						    rxParameters.getValue("Progress");
+						std::string progressStr = rxParameters.getValue("Progress");
 						if(!progressStr.empty())
 							realProgressOut->store(std::stoi(progressStr));
 					}

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.h
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.h
@@ -229,7 +229,7 @@ class MacroMakerSupervisor : public CoreSupervisorBase
 	                       bool               saveOutputs,
 	                       const std::string& username,
 	                       const std::string& userGroupPermissions,
-	                       bool               saveToHistory = true,
+	                       bool               saveToHistory   = true,
 	                       std::atomic<int>*  realProgressOut = nullptr);
 	static void runFEMacroGroupSchedulerThread(std::shared_ptr<runFEMacroGroupStruct> group,
 	                                           MacroMakerSupervisor*                  mmSupervisor);

--- a/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.h
+++ b/otsdaq-utilities/MacroMaker/MacroMakerSupervisor.h
@@ -76,6 +76,7 @@ class MacroMakerSupervisor : public CoreSupervisorBase
 		runFEMacroStruct(runFEMacroStruct&& other) noexcept
 		    : parameters_(other.parameters_)
 		    , feMacroRunDone_(other.feMacroRunDone_.load())
+		    , realProgress_(other.realProgress_.load())
 		{
 		}
 		/// Allow move constructor because std::atomic is not copyable, for vector erase
@@ -85,12 +86,14 @@ class MacroMakerSupervisor : public CoreSupervisorBase
 			{
 				parameters_ = other.parameters_;
 				feMacroRunDone_.store(other.feMacroRunDone_.load());
+				realProgress_.store(other.realProgress_.load());
 			}
 			return *this;
 		}
 
 		runFEMacroParameterStruct    parameters_;
 		std::atomic<bool>            feMacroRunDone_ = false;
+		std::atomic<int>             realProgress_   = -1;
 		std::unique_ptr<ProgressBar> bar_;
 	};  //end runFEMacroStruct struct
 
@@ -226,7 +229,8 @@ class MacroMakerSupervisor : public CoreSupervisorBase
 	                       bool               saveOutputs,
 	                       const std::string& username,
 	                       const std::string& userGroupPermissions,
-	                       bool               saveToHistory = true);
+	                       bool               saveToHistory = true,
+	                       std::atomic<int>*  realProgressOut = nullptr);
 	static void runFEMacroGroupSchedulerThread(std::shared_ptr<runFEMacroGroupStruct> group,
 	                                           MacroMakerSupervisor*                  mmSupervisor);
 	static void runFEMacroThread(std::shared_ptr<runFEMacroStruct> feMacroRunThreadStruct,


### PR DESCRIPTION
… XOAP timeout. This was addressed now by detaching the FEMacro execution at the FESupervisor. As a byproduct, better progress tracking is enabled if FEMacros call setFEMacroPercentDone(0-100)