### PR TITLE
Removing alias check in extractLayoutToForm

### DIFF
--- a/WebGUI/html/UserSettings.html
+++ b/WebGUI/html/UserSettings.html
@@ -296,18 +296,6 @@
 				else
 					el.innerHTML = "Layout Details: <a href='#' onmouseup='showLayoutText(" +
 						(i + 1) + ",true,event); return false;'>show</a>";
-
-				//update alias input to match current alias array
-				var aliasEl = document.getElementById("winLayoutAlias" + (i + 1));
-				if (aliasEl) {
-					if (_layoutAliasArray[i] == "-1" || _layoutAliasArray[i] == (i + 1).toString() ||
-						_layoutAliasArray[i] == (i + 1)) {
-						aliasEl.value = "";
-						aliasEl.setAttribute("placeholder", "Enter Alias");
-					}
-					else
-						aliasEl.value = _layoutAliasArray[i];
-				}
 			}
 
 			//if user has privileges _sysLayoutArray is populated
@@ -326,18 +314,6 @@
 				else
 					el.innerHTML = "Layout Details: <a href='#' onmouseup='showLayoutText(" +
 						(i + 1) + ",true,event,1); return false;'>show</a>";
-
-				//update system alias input to match current alias array
-				var sysAliasEl = document.getElementById("winSysLayoutAlias" + (i + 1));
-				if (sysAliasEl) {
-					if (_sysLayoutAliasArray[i] == "-1" || _sysLayoutAliasArray[i] == (i + 1).toString() ||
-						_sysLayoutAliasArray[i] == (i + 1)) {
-						sysAliasEl.value = "";
-						sysAliasEl.setAttribute("placeholder", "Enter Alias");
-					}
-					else
-						sysAliasEl.value = _sysLayoutAliasArray[i];
-				}
 			}
 
 		} //end extractLayoutToForm()


### PR DESCRIPTION
Removed alias checks from `extractLayoutToForm`. The existing logic prevented new aliases from being added through the form. 


Behavior with the current `develop` branch 


https://github.com/user-attachments/assets/46fa8d82-c16f-4f20-9416-ce8b67293d9b






Behavior with changes introduced 


https://github.com/user-attachments/assets/7af1a1e1-1781-4331-a9d9-ccdf849cfc8a





